### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,10 @@ name: Docker Image CI
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MegaMek/megamek-docker-image/security/code-scanning/1](https://github.com/MegaMek/megamek-docker-image/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimum required permissions. Based on the actions used in the workflow, the following permissions are necessary:
- `contents: read` for accessing repository contents (e.g., during `actions/checkout`).
- `packages: write` for pushing Docker images to Docker Hub.

The `permissions` block will be added at the root of the workflow, ensuring it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
