### PR TITLE
Nonroot container, that is smaller and builds faster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ FROM gcr.io/distroless/java25-debian13:nonroot
 WORKDIR /app
 EXPOSE 2346
 
+# Chown to nonroot user, so that it can access the files within /app.
+# But, in the case of running within OpenShift, a random userid will be used.
+# To ensure the image still functions in that scenario, use groupid 0.
 COPY --from=builder --chown=nonroot:0 /app/megamek/ /app/
 
 ENTRYPOINT ["java", "-jar", "MegaMek.jar"]


### PR DESCRIPTION
Hi!

I made some adjustments to the Dockerfile to do the following:

- Switch to an Alpine build image (~9 MiB vs ~103 MiB) for faster pulls on initial build
- Remove install step in build container, as curl isn't used at all
- Use a distroless container image, decreasing the size and security profile of the resulting image (~420 vs ~700 MiB)
- Update to a newer LTS release for the JRE
- Make the image nonroot

The last one being the primary motivator. Making the image non-root improves the security profile of the image, and allows it to run in stricter k8s namespaces (tested) and should now also function in OpenShift (untested, see [1]). I believe this is important as these images might be exposed to the internet and as such should have basic security precautions taken.

As this change makes the container run with less privileges, users who run this container in a 'rootful' manner may need to adjust permissions on the (contents of) their user data volume.


[1]: For ownership of `/app/`, the GID is set to 0, instead of the user's group, to be able to deal with the random user ID assignment strategy OpenShift applies: "The Container user is always a member of the root group, so it can read or write files accessible by GID=0" ([A Guide to OpenShift and UIDs](https://www.redhat.com/en/blog/a-guide-to-openshift-and-uids), [W. C. Babilonia](https://www.redhat.com/en/authors/william-caban-babilonia))