### PR TITLE
Fix home-dir permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,14 @@ RUN tar -zxvf /tmp/megamek.tar.gz && mv MegaMek-${MM_VERSION} megamek && \
 
 FROM eclipse-temurin:21-noble
 
-WORKDIR /app
-EXPOSE 2346
-
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
   && apt-get -q update \
   && apt-get -q full-upgrade -y \
   && apt-get clean && \
   useradd --user-group --create-home --system --skel /dev/null --home-dir /app megamek
 
+WORKDIR /app
+EXPOSE 2346
 USER megamek
 
 COPY --from=builder --chown=megamek:megamek /app/megamek/ /app/


### PR DESCRIPTION
Move WORKDIR after user creation as docker build is creating this folder with `root:root` permissions. Also moved EXPOSE down to kinda "cluster" things.

This fixes java warnings about user preferences:
```txt
May 27, 2026 6:13:37 AM java.util.prefs.FileSystemPreferences$1 run
WARNING: Couldn't create user preferences directory. User preferences are unusable.
May 27, 2026 6:13:37 AM java.util.prefs.FileSystemPreferences$1 run
WARNING: java.io.IOException: No such file or directory
May 27, 2026 6:14:08 AM java.util.prefs.FileSystemPreferences checkLockFile0ErrorCode
WARNING: Could not lock User prefs.  Unix error code 2.
May 27, 2026 6:14:08 AM java.util.prefs.FileSystemPreferences syncWorld
WARNING: Couldn't flush user prefs: java.util.prefs.BackingStoreException: Couldn't get file lock.
```

Some alternatives I considered were as follows but this made the most since to me as the container is already ephemeral and doesn't add complications.

- Add a tmpfs mount at runtime.
- Modify entrypoint with Java system properties which force the use of /tmp